### PR TITLE
Remove reference to lodash that was dropped

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ A `Node.js` and `Express.js` version of the Countries API example.
 
 Developed using Node v4.1.0.
 
-Babel.JS for ES6 compatibility. lodash for utilities. Mocha for testing. eshint for linting.
+Babel.JS for ES6 compatibility. Mocha for testing. eshint for linting.
 
     npm install
     npm run-script lint


### PR DESCRIPTION
Don't mention unused dependency in README